### PR TITLE
Rearranged classifications sections to traditional industries and added Elsevier

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -1,17 +1,21 @@
 # TDMRep Adopters
 
-This page contains a list of adopters of the TDM Reservation Protocol. Adopters are grouped by country. 
+This page contains a list of adopters of the TDM Reservation Protocol. Adopters are grouped by type of industry. 
 
-## France
-
-### Book Publishers
+## Trade Publishers
 - Hachette Livre: most of the publishing houses of the Hachette group have implemented the protocol on their website. Here a some of them: Hachette.fr, Hachette Romans, Hachette Pratique, Livre de Poche, Hatier, Grasset, Fayard, Editions Larousse, Bescherelle, Pika, Audiolib ...   
 - Media-Participations has adopted the protocol in its different publishing houses, including La Martinière, Seuil, Fleurus ..
+- Mondadori has adopted the protocol on the websites [Mondadori](https://www.mondadori.it/) and [Oscar](https://www.oscarmondadori.it/). 
+- Penguin Random House Spain has adopted the protocol in its EPUB files. 
+- Penguin Random House Germany has adopted the protocol in its ONIX records. 
+- Aufbau has also adopted the protocol.
+- Diogenes has adopted the protocol.
 
-### STM
+## STM Publishers
 - Cairn Info (https://www.cairn.info/): as http headers + html metadata, with a policy.
+- Elsevier (https://www.elsevier.com/): as tdmrep.json, with a policy.
 
-### Newspapers
+## Newspapers
 - Ouest France (https://www.ouest-france.fr/): as html metadata, with a policy.
 - Sud Ouest (https://www.sudouest.fr/): as tdmrep.json, with a policy.
 - Les Echos (https://www.lesechos.fr/): as html metadata, with a policy.
@@ -25,24 +29,3 @@ This page contains a list of adopters of the TDM Reservation Protocol. Adopters 
 A daily update is available on [Mind Media](https://www.mind.eu.com/media/data/ia-generative-quels-editeurs-francais-bloquent-les-robots-dopenai-et-google-lesquels-ont-adopte-le-protocole-tdmrep/), a French online media which maintains a robot developed using [datawrapper](https://www.datawrapper.de/_/607Cd/). 
 
 Cherry on the cake: this tool provides links to the TDM policy files of each newspaper. 
-
-## Italy
-
-### Book Publishers
-- Mondadori has adopted the protocol on the websites [Mondadori](https://www.mondadori.it/) and [Oscar](https://www.oscarmondadori.it/). 
-
-## Spain
-
-### Book Publishers
-- Penguin Random House Spain has adopted the protocol in its EPUB files. 
-
-## Germany
-
-### Book Publishers
-- Penguin Random House Germany has adopted the protocol in its ONIX records. 
-- Aufbau has also adopted the protocol.
-
-## Switzerland
-
-### Book Publishers 
-- Diogenes  has  adopted the protocol.


### PR DESCRIPTION
From email conversation with W3C and STM, changed the adopters section to reflect publishing industry and added Elsevier as an adopter.