### PR TITLE
Added Springer Nature and APA to Adopters List

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -16,7 +16,7 @@ This page contains a list of adopters of the TDM Reservation Protocol. Adopters 
 - Cairn Info (https://www.cairn.info/): as http headers + html metadata, with a policy.
 - Elsevier (https://www.elsevier.com/): as tdmrep.json, http headers + html metadata, with a policy.
 - American Chemical Society (https://pubs.acs.org/): as tdmrep.json, with a policy.
-- Spinger Nature (https://www.springernature.com/): as tdmrep.json, with a policy.
+- Springer Nature (https://www.springernature.com/): as tdmrep.json, with a policy.
 
 ## Newspapers
 - Ouest France (https://www.ouest-france.fr/): as html metadata, with a policy.

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -16,6 +16,7 @@ This page contains a list of adopters of the TDM Reservation Protocol. Adopters 
 - Cairn Info (https://www.cairn.info/): as http headers + html metadata, with a policy.
 - Elsevier (https://www.elsevier.com/): as tdmrep.json, http headers + html metadata, with a policy.
 - American Chemical Society (https://pubs.acs.org/): as tdmrep.json, with a policy.
+- Spinger Nature (https://www.springernature.com/): as tdmrep.json, with a policy.
 
 ## Newspapers
 - Ouest France (https://www.ouest-france.fr/): as html metadata, with a policy.

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -17,6 +17,7 @@ This page contains a list of adopters of the TDM Reservation Protocol. Adopters 
 - Elsevier (https://www.elsevier.com/): as tdmrep.json, http headers + html metadata, with a policy.
 - American Chemical Society (https://pubs.acs.org/): as tdmrep.json, with a policy.
 - Springer Nature (https://www.springernature.com/): as tdmrep.json, with a policy.
+- American Psychological Association (https://www.apa.org): as http headers + html metadata, with a policy.
 
 ## Newspapers
 - Ouest France (https://www.ouest-france.fr/): as html metadata, with a policy.

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -17,7 +17,7 @@ This page contains a list of adopters of the TDM Reservation Protocol. Adopters 
 - Elsevier (https://www.elsevier.com/): as tdmrep.json, http headers + html metadata, with a policy.
 - American Chemical Society (https://pubs.acs.org/): as tdmrep.json, with a policy.
 - Springer Nature (https://www.springernature.com/): as tdmrep.json, with a policy.
-- American Psychological Association (https://www.apa.org): as http headers + html metadata, with a policy.
+- American Psychological Association (https://psycnet.apa.org, https://psycinfo.apa.org, https://academicwriter.apa.org, and https://psyctherapy.apa.org): as http headers + html metadata, with a policy.
 
 ## Newspapers
 - Ouest France (https://www.ouest-france.fr/): as html metadata, with a policy.


### PR DESCRIPTION
The adopters.md file now has Springer Nature and American Psychological Association as adopters of the TDMRep protocol.