### PR TITLE
Update adopters.md adding Optica Publishing Group and IEEE to STM

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -21,6 +21,7 @@ The following Science, Technology and Mathematics publishers has adopted the pro
 - American Chemical Society (https://pubs.acs.org/): as tdmrep.json, with a policy.
 - Springer Nature (https://www.springernature.com/): as tdmrep.json, with a policy.
 - American Psychological Association (https://psycnet.apa.org, https://psycinfo.apa.org, https://academicwriter.apa.org, and https://psyctherapy.apa.org): as http headers + html metadata, with a policy.
+- Optica Publishing Group (https://opg.optica.org/): as tdmrep.json, Crossref metadata, PDF XMP Metadata, with a policy
 
 ## Digital Platforms
 They are contracted by publishers to distribute digital content. 

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -22,6 +22,7 @@ The following Science, Technology and Mathematics publishers has adopted the pro
 - Springer Nature (https://www.springernature.com/): as tdmrep.json, with a policy.
 - American Psychological Association (https://psycnet.apa.org, https://psycinfo.apa.org, https://academicwriter.apa.org, and https://psyctherapy.apa.org): as http headers + html metadata, with a policy.
 - Optica Publishing Group (https://opg.optica.org/): as tdmrep.json, Crossref metadata, PDF XMP Metadata, with a policy
+- IEEE (https://www.ieee.org): as tdmrep.json, with a policy.
 
 ## Digital Platforms
 They are contracted by publishers to distribute digital content. 


### PR DESCRIPTION
Optica extensively using W3C TDMRep recommendation.