### PR TITLE
Fix Typo in Domain (swpawning.ai -> spawning.ai)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -324,7 +324,7 @@
         <p>`tdm-reservation` and the optional `tdm-policy` are two properties added to the HTTP header of the response to a GET or HEAD request.</p>
 
         <div class="note">
-          <p>This is currently the preferred technique for implementing the protocol, as it is simple and already integrated in the swpawning.ai API.</p>
+          <p>This is currently the preferred technique for implementing the protocol, as it is simple and already integrated in the spawning.ai API.</p>
         </div>
 
         <p>In the following example, the rightsholder expresses that TDM rights are reserved on these files with no way to acquire a TDM License. The server returns a `tdm-reservation` header field with value <code>1</code>.


### PR DESCRIPTION
The document mentions `swpawning.ai`, which is a domain that currently does not exist.
I'm assuming it was intended to instead be `spawning.ai`, which does exist.

This is a very small change, so it might not even be worth a PR, but I felt like it.